### PR TITLE
Side Menu & Footer Fixed

### DIFF
--- a/common/csslinks.html
+++ b/common/csslinks.html
@@ -17,6 +17,3 @@
 <link rel="icon" href="/images/favicon.ico" type="image/x-icon" / >
 <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon" / >
 
-<!--Scripts for header-->
-<script src="/scripts/sidemenu.js" type="text/javascript"></script>
-

--- a/common/footer.html
+++ b/common/footer.html
@@ -15,6 +15,7 @@
   </table>
 </div>
 <div id="copyright">
-  <p>Copyright © 2023 CKEFGISC 建北電資，以 MIT 授權條款釋出。</p>
+  <p>Copyright © 2023 CKEFGISC 建北電資</p>
+  <p>以 MIT 授權條款釋出</p>
   <p>原始碼存放於 <a href="https://github.com/CKEFGISC/CKEFGISC.github.io">Github</a></p>
 </div>

--- a/common/header.html
+++ b/common/header.html
@@ -12,4 +12,5 @@
   <li><a href="/event">活動</a></li>
   <li><a href="/schedule">行事曆</a></li>
 </ul>
+<script src="/scripts/sidemenu.js" type="text/javascript"></script>
 

--- a/styles/footer.css
+++ b/styles/footer.css
@@ -24,3 +24,13 @@ footer td {
   line-height: 0.5vw;
 }
 
+@media only screen and (max-width: 800px) {
+  footer div {
+    margin: 7vw 0;
+  }
+
+  #copyright p {
+    line-height: unset;
+  }
+}
+


### PR DESCRIPTION
As the title suggests, I have taken care of the issue regarding the malfunction of the side menu. It turns out that even though I did the jQuery `.ready()` thing to make sure the menu button itself is loaded before the scripts try to bind the `.click()` event to it, because the `<script>` tag is included along with the CSS links, it doesn't account for the header, which is being included from somewhere else.

Therefore, the simplest solution is to put the `<script>` tag in the `/common/header.html`. Although it might look a little bit weird to have a `<script>` tag in the middle of `<body>`, it does work and LGTM.