### PR TITLE
Sticked footer to the bottom

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -19,9 +19,10 @@
 
   <img class="bannerImage" src="../images/about/banner.jpg">
 
-
-  <i class="icon fa-solid fa-trophy"></i>
-  <div class="title">關於建北電資</div>
+  <div>
+    <i class="icon fa-solid fa-trophy"></i>
+    <div class="title">關於建北電資</div>
+  </div>
   <li class="ti1">社史</li>
   <p class="content">好奇乃人類之天性，知識是實現夢想之道，而真理則是心靈最安寧的歸宿。<br>建電與北資自1995年合併，至今已傳承至27屆，並和稱建北電資，也因為如此，雙方也培養出了許多情感<s>或愛情</s>，並且兩社合作密切，不只是春夏秋冬的大活動，連宣幹或放學的小社課也都是一起舉辦的。<br>如果你覺得女校或男校的生活太無聊，建北電資會告訴你什麼叫把男女分校當成男女混校，我們常常一起出去社遊，也常常會聽到有北資的說，ㄟ要不要去建電社辦，諸如此類的，在常人來看，建北電資根本就是同一個社團。 </p>
   <li class="ti1">吉祥物 - 蘇格拉底雞</li>
@@ -30,8 +31,10 @@
     <p class="mark">北資的吉祥物，後經建電學長發揚光大後，成為建北電資的吉祥物，會出現在宣幹卡片上的可愛小雞。聽說歷屆學長姐對於蘇格拉底雞到底有沒有手爭論不已。一一以上學長姐皆表示它沒有手，但是一二十分堅持蘇格拉底雞應該有手。到底真相是什麼呢？有待各位努力找出來了XD。</p>
   </div>
   <br>
-  <i class="icon fa-solid fa-computer-mouse"></i>
-  <div class="title">關於建電</div>
+  <div>
+    <i class="icon fa-solid fa-computer-mouse"></i>
+    <div class="title">關於建電</div>
+  </div>
   <li class="ti1">社史</li>
   <p class="content">建國中學電子計算機研習社創社於民國 1980 年，現今已有42年的歷史，現任社師為潘威歷老師。大社課由幹部教授C++，並鼓勵社員參與競賽和檢定。放學的小社課秉持一直以來的多元化傳統，有許多不同面向的資訊課程，也和北一女中資訊研習社有密切的合作關係，會共同籌辦活動維繫感情，放學的小社課也會和北一女中的學生一起上課。</p>
   <li class="ti1">社徽 - CK鼠</li>
@@ -40,8 +43,10 @@
     <p class="mark">結合了學長們的智慧以及創意設計成的社徽，把社團英文縮寫CKEISC設計成滑鼠的圖案，因此也被大眾戲稱為CK鼠。</p>
   </div>
   <br>
-  <i class="icon fa-regular fa-star"></i>
-  <div class="title">關於北資</div>
+  <div>
+    <i class="icon fa-regular fa-star"></i>
+    <div class="title">關於北資</div>
+  </div>
   <li class="ti1">社史</li>
   <p class="content">北一女中資訊研習社創社於民國 76 年 11 月 11 日，現任社師為何雪臻老師。有屬於我們社團獨自的BBS站，大社課教授C++，並鼓勵社員參與競賽，歷屆許多表現十分優異學姊。中午和放學的額社秉持一直以來的多元化傳統，致力提升校內資訊風氣。也有各式活動聯絡彼此感情。</p>
   <li class="ti1">社徽 - 小弗星</li>
@@ -49,8 +54,10 @@
     <img class="image" src="../images/about/fgisc_star.png">
     <p class="mark">極富創意及意義的社徽,把英文社名縮寫 FGISC 化為星星和月亮,此標誌被稱為弗基斯特星座、簡稱小弗星。</p>
   </div>
-  <i class="icon fa-solid fa-computer"></i>
-  <div class="title">關於本站</div>
+  <div>
+    <i class="icon fa-solid fa-computer"></i>
+    <div class="title">關於本站</div>
+  </div>
   <p class="content">本站是由一三的嗯嗯、鹽亞倫、溫室蔡及建北電資一三的幹部們架設。更多關於本站之資訊，請見<a href="site.html" class="aaa"><b>關於本站</b></a>頁面。
   </p>
 

--- a/styles/footer.css
+++ b/styles/footer.css
@@ -40,7 +40,7 @@ footer {
 
 @media only screen and (max-width: 1100px) {
   footer {
-    display: inherit;
+    display: initial;
     font-size: 18px;
     padding-bottom: 10vw;
   }

--- a/styles/global.css
+++ b/styles/global.css
@@ -6,10 +6,17 @@ body {
   margin: 0;
   background-color: var(--soft-white);
   font-family: "Noto Sans TC", "微軟正黑體", "Microsoft Jhenghei", sans-serif;
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
 }
 
 * {
   caret-color: rgba(0, 0, 0, 0);
+}
+
+#main-container {
+  flex: 1;
 }
 
 .top {


### PR DESCRIPTION
Apparently, the problem can be solved by making the whole `<body>` into a giant flexbox.

There are some consequences, though. For example, the about page's section titles have icons, and they are supposed to be on the same row, but the flexbox broke it. This was easily fixed by grouping the icon and the title text into a `<div>`, but we still need to be careful during future developments.